### PR TITLE
Add environment based path prefix

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,14 @@ class ApplicationController < ActionController::Base
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
   protect_from_forgery with: :exception
+
+  def path_for_environment
+    "app/views/#{environment_folder}"
+  end
+
+  def environment_folder
+    # This would actually be an environment variable, but for
+    # demo purposes we're using a param here.
+    params[:application_type].downcase if params[:application_type].present?
+  end
 end

--- a/app/controllers/books_controller.rb
+++ b/app/controllers/books_controller.rb
@@ -74,6 +74,6 @@ class BooksController < ApplicationController
     end
 
     def set_view_path
-      prepend_view_path('app/views/enterprise') if rand(10) % 2 == 0
+      prepend_view_path(path_for_environment)
     end
 end

--- a/app/views/enterprise/books/index.html.erb
+++ b/app/views/enterprise/books/index.html.erb
@@ -1,6 +1,6 @@
 <p id="notice"><%= notice %></p>
 
-<h1>Listing Books</h1>
+<h1>Enterprise - Listing Books</h1>
 
 <table>
   <thead>


### PR DESCRIPTION
I've updated the example app to use environment based path prefixes
and also changed the Enterprise index to include the word
"Enterprise" to make it easier to tell which view is being rendered.
